### PR TITLE
Fix installation with custom CMAKE_INSTALL_PREFIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/custom_variables.cmake")
 endif()
 
 set(CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/cmake")
+set(KUMIR2_INSTALL_PREFIX "${CMAKE_INSTALL_PREFIX}")
 find_package(Kumir2 REQUIRED)
 
 include_directories("${CMAKE_SOURCE_DIR}/include")


### PR DESCRIPTION
STR: run cmake with -DCMAKE_INSTALL_PREFIX=/some_user_dir, then make, then make install without root privileges.
AR: make install failed trying to copy some file to /usr/lib
ER: make install is successful
